### PR TITLE
xorg-libxcb is deprecated

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   md5: {{ md5 }}
 
 build:
-  number: 1000
+  number: 1001
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("fltk", max_pin="x.x") }}
@@ -32,7 +32,7 @@ requirements:
     - xorg-libxext
     - xorg-libxdmcp
     - xorg-libxau
-    - xorg-libxcb
+    - libxcb
     - xorg-libxfixes
     - xorg-libxrender
     - xorg-libx11
@@ -46,7 +46,7 @@ requirements:
     - xorg-libxext
     - xorg-libxdmcp
     - xorg-libxau
-    - xorg-libxcb
+    - libxcb
     - xorg-libxfixes
     - xorg-libxrender
     - xorg-libx11


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
